### PR TITLE
Add tab page data load cache

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -54,7 +54,7 @@ class Demo extends React.Component {
     return (
       <div>
         <button onClick={this.addItem}>Add item</button>
-        <button onClick={() => this.setState({activeIndex: 0})}>Reset index</button>
+        <button onClick={() => this.setState({ activeIndex: 0 })}>Reset index</button>
         <CloseableTabs
           tabPanelColor='lightgray'
           data={this.state.data}
@@ -64,7 +64,7 @@ class Demo extends React.Component {
               activeIndex: newIndex
             });
           }}
-          noTabUnmount
+
           activeIndex={this.state.activeIndex}
         />
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -159,8 +159,8 @@ class ReactCloseableTabs extends Component {
           })}
         </TabPanel>
         <TabContent className={this.props.tabContentClass || ''}>
-          {
-            Object.values(domActived).map((item, index) => {
+          {noTabUnmount
+            ? Object.values(domActived).map((item, index) => {
               return (
                 <div
                   key={item.id || index}
@@ -169,7 +169,9 @@ class ReactCloseableTabs extends Component {
                   {item.component}
                 </div>
               )
-            })
+            }) : data[activeIndex]
+              ? data[activeIndex].component
+              : null
           }
         </TabContent>
       </CloseableTabs>

--- a/src/index.js
+++ b/src/index.js
@@ -78,10 +78,12 @@ class ReactCloseableTabs extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    const { domActived } = this.state;
+    const { data, activeIndex } = nextProps;
+    let currentId = data[activeIndex].id;
     if (nextProps.data) {
-      const newState = {
-        data: nextProps.data
-      }
+      domActived[currentId] = data[activeIndex];
+      const newState = { data, domActived }
       if (Number.isInteger(nextProps.activeIndex)) {
         newState.activeIndex = nextProps.activeIndex
       }
@@ -116,11 +118,11 @@ class ReactCloseableTabs extends Component {
       const { data, domActived, identifier } = this.state;
       data.filter(item => item.id !== id);
       const nextId = data[newIndex][identifier];
-      if (domActived[id]) {
-        delete domActived[id];
-      }
       if (!domActived[nextId]) {
         domActived[nextId] = data[newIndex]
+      }
+      if (domActived[id]) {
+        delete domActived[id];
       }
       this.setState({ data, activeIndex: newIndex, domActived })
     }

--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,9 @@ class ReactCloseableTabs extends Component {
   }
 
   componentWillMount() {
-    const { domActived, activeIndex, data } = this.state;
-    domActived[activeIndex] = data[activeIndex];
+    const { domActived, activeIndex, data, identifier } = this.state;
+    let currentId = data[activeIndex][identifier];
+    domActived[currentId] = data[activeIndex];
     this.setState({ domActived });
   }
 
@@ -89,10 +90,11 @@ class ReactCloseableTabs extends Component {
   }
 
   handleTabClick = (id, index) => {
-    const { domActived, data } = this.state;
+    const { domActived, data, identifier } = this.state;
     this.props.onBeforeTabClick &&
       this.props.onBeforeTabClick(id, index, this.state.activeIndex)
-    domActived[index] = data[index];
+    let currentId = data[index][identifier];
+    domActived[currentId] = data[index];
     this.setState({ activeIndex: index, domActived }, () => {
       this.props.onTabClick &&
         this.props.onTabClick(id, index, this.state.activeIndex)
@@ -105,22 +107,28 @@ class ReactCloseableTabs extends Component {
       this.state.identifier
     ]
     const newIndex =
-      activeId === id ? this.state.activeIndex - 1 : this.state.activeIndex
+      activeId >= id ? this.state.activeIndex - 1 : this.state.activeIndex
     let canClose = true;
     if (this.props.onCloseTab) {
       canClose = this.props.onCloseTab(id, newIndex)
     }
     if (canClose !== false) {
-      this.setState({
-        data: this.state.data.filter(item => item.id !== id),
-        activeIndex: newIndex
-      })
+      const { data, domActived, identifier } = this.state;
+      data.filter(item => item.id !== id);
+      const nextId = data[newIndex][identifier];
+      if (domActived[id]) {
+        delete domActived[id];
+      }
+      if (!domActived[nextId]) {
+        domActived[nextId] = data[newIndex]
+      }
+      this.setState({ data, activeIndex: newIndex, domActived })
     }
   }
 
   render() {
     const { noTabUnmount } = this.props
-    const { domActived, activeIndex, data } = this.state
+    const { domActived, activeIndex, data, identifier } = this.state
     return (
       <CloseableTabs className={this.props.mainClassName || ''}>
         <TabPanel
@@ -154,7 +162,7 @@ class ReactCloseableTabs extends Component {
               return (
                 <div
                   key={item.id || index}
-                  style={{ display: index === activeIndex ? 'block' : 'none' }}
+                  style={{ display: item.id === data[activeIndex][identifier] ? 'block' : 'none' }}
                 >
                   {item.component}
                 </div>

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,14 @@ class ReactCloseableTabs extends Component {
   state = {
     data: this.props.data,
     activeIndex: this.props.activeIndex || 0,
-    identifier: this.props.identifier || 'id'
+    identifier: this.props.identifier || 'id',
+    domActived: {}
+  }
+
+  componentWillMount() {
+    const { domActived, activeIndex, data } = this.state;
+    domActived[activeIndex] = data[activeIndex];
+    this.setState({ domActived });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -82,9 +89,11 @@ class ReactCloseableTabs extends Component {
   }
 
   handleTabClick = (id, index) => {
+    const { domActived, data } = this.state;
     this.props.onBeforeTabClick &&
       this.props.onBeforeTabClick(id, index, this.state.activeIndex)
-    this.setState({ activeIndex: index }, () => {
+    domActived[index] = data[index];
+    this.setState({ activeIndex: index, domActived }, () => {
       this.props.onTabClick &&
         this.props.onTabClick(id, index, this.state.activeIndex)
     })
@@ -111,7 +120,7 @@ class ReactCloseableTabs extends Component {
 
   render() {
     const { noTabUnmount } = this.props
-    const { data, activeIndex } = this.state
+    const { domActived, activeIndex, data } = this.state
     return (
       <CloseableTabs className={this.props.mainClassName || ''}>
         <TabPanel
@@ -140,18 +149,18 @@ class ReactCloseableTabs extends Component {
           })}
         </TabPanel>
         <TabContent className={this.props.tabContentClass || ''}>
-          {noTabUnmount
-            ? data.map((item, index) => (
+          {
+            Object.values(domActived).map((item, index) => {
+              return (
                 <div
                   key={item.id || index}
                   style={{ display: index === activeIndex ? 'block' : 'none' }}
                 >
                   {item.component}
                 </div>
-              ))
-            : data[activeIndex]
-            ? data[activeIndex].component
-            : null}
+              )
+            })
+          }
         </TabContent>
       </CloseableTabs>
     )


### PR DESCRIPTION
In the previous version, after I loaded the data in the current tab, I switched to another tab and switched back. The data in the current tab is reloaded. This is not the effect I want. So I made a change to the rendering method: After rendering the current tab page, I will cache the data, and the next time I enter the tab page, I don't need to load the data to render the data I want.