### PR TITLE
Fix redundant dom not cleared

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -9,29 +9,52 @@ class Demo extends React.Component {
       {
         tab: 'List',
         component: <div><h1>Your list</h1></div>,
-        id: 0,
+        id: 6,
         closeable: false
       },
       {
         tab: 'Item detail 1',
         component: <div>Item details for 1</div>,
-        id: 1,
-        closeable: true
-      },
-      {
-        tab: 'Item detail 2',
-        component: <div>Item details for 2</div>,
-        id: 2,
-        closeable: true
-      },
-      {
-        tab: 'Item detail 3',
-        component: <div>Item details for 3</div>,
-        id: 3,
+        id: 7,
         closeable: true
       }
-    ]
+    ],
+    activeIndex: 1
   };
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({
+        data: [
+          {
+            tab: 'List',
+            component: <div><h1>Your list</h1></div>,
+            id: 0,
+            closeable: false
+          },
+          {
+            tab: 'Item detail 1',
+            component: <div>Item details for 1</div>,
+            id: 1,
+            closeable: true
+          },
+          {
+            tab: 'Item detail 2',
+            component: <div>Item details for 2</div>,
+            id: 2,
+            closeable: true
+          },
+          {
+            tab: 'Item detail 3',
+            component: <div>Item details for 3</div>,
+            id: 3,
+            closeable: true
+          }
+        ],
+        activeIndex: 2
+      })
+    }, 2000)
+  }
 
   addItem = () => {
     const id = new Date().valueOf();
@@ -64,7 +87,7 @@ class Demo extends React.Component {
               activeIndex: newIndex
             });
           }}
-
+          noTabUnmount
           activeIndex={this.state.activeIndex}
         />
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-closeable-tabs",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "description": "Simple closeable tabs. Add or remove tabs",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -69,12 +69,22 @@ class ReactCloseableTabs extends Component {
     identifier: this.props.identifier || 'id',
     domActived: {}
   }
-
   componentWillMount() {
     const { domActived, activeIndex, data, identifier } = this.state;
+    if (!data[activeIndex]) return;
     let currentId = data[activeIndex][identifier];
     domActived[currentId] = data[activeIndex];
     this.setState({ domActived });
+  }
+
+  componentDidUpdate() {
+    const { data, domActived } = this.state;
+    const arr = Object.values(domActived).filter((item) => {
+      return Object.values(data).map(item => (item.id)).indexOf(item.id) === -1
+    })
+    if (arr.length <= 0) return false;
+    delete domActived[arr[0].id];
+    this.setState({ domActived })
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
In the previous version, I had a default dom added to the cache page before the asynchronous loading of the tab page, but after the asynchronous loading was completed, the default page was not removed, resulting in a redundant dom structure in my project. In this update, I judge whether the data in the cache exists in the newly passed data in the ‘componentDidUpdate’ hook, and delete it if it does not exist.